### PR TITLE
Add Support for GitHub Stage Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ The following table shows all of the currently supported steps.
 | [`collectCode`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/collectCode.groovy) | Uses the standard `checkout scm` command (only available for multi-branch pipelines) along with a git fetch. |
 | [`isPypiPublishable`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/isPypiPublishable.groovy) | Checks branch conditions to see if the python package should be published. |  
 | [`publishDockerImage`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/publishDockerImage.groovy) | Publishes a docker image to a registry.  By default the name of the image should contain the registry to publish to in the form `your-registry/image-name:tag`.  There is an option to specify a registry with a URL. |
-| [`publishPythonPackage`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/publishPythonPackage.groovy | Creates a python package out of the project and publishes it to pypi. |
+| [`publishPythonPackage`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/publishPythonPackage.groovy) | Creates a python package out of the project and publishes it to pypi. |
 | [`removeDockerImage`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/removeDockerImage.groovy) | Removes the built Docker image from the server. |
+| [`reportableStage`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/reportableStage.groovy) | Reports the status of the stage to in the commit status notification. |
 | [`runNodeTestSuite`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/runNodeTestSuite.groovy) | Runs a node test suite. |
 | [`runPythonTestSuite`](https://github.com/pacificclimate/jenkins-library/blob/master/vars/runPythonTestSuite.groovy) | Runs a python test suite. |
 

--- a/src/org/pcic/GitHubUtils.groovy
+++ b/src/org/pcic/GitHubUtils.groovy
@@ -1,0 +1,42 @@
+package org.pcic
+
+
+class GitHubUtils implements Serializable {
+    def steps
+
+    GitHubUtils(steps) {
+        this.steps = steps
+    }
+
+    void setBuildStatus(String context, String message, String state) {
+        steps.step([
+            $class: "GitHubCommitStatusSetter",
+            contextSource: [
+              $class: "ManuallyEnteredCommitContextSource",
+              context: context
+            ],
+            errorHandlers: [[
+              $class: "ChangingBuildStatusErrorHandler",
+              result: "UNSTABLE"
+            ]],
+            reposSource: [
+                $class: "ManuallyEnteredRepositorySource",
+                url: "https://github.com/${getRepo()}"
+            ],
+            statusResultSource: [
+                $class: "ConditionalStatusResultSource",
+                results: [[
+                    $class: "AnyBuildResult",
+                    message: message,
+                    state: state
+                ]]
+            ]
+        ])
+    }
+
+    private String getRepo() {
+        def tokens = "${steps.env.JOB_NAME}".tokenize('/')
+        def repo = tokens[tokens.size() - 2]
+        return "pacificclimate/${repo}"
+    }
+}

--- a/src/org/pcic/util/Utils.groovy
+++ b/src/org/pcic/util/Utils.groovy
@@ -101,4 +101,8 @@ class Utils implements Serializable {
         String installs = packages.join(' ')
         steps.sh(script: "apt-get install -y ${installs}")
     }
+
+    String getExceptionType(Exception e) {
+        return e.toString().tokenize(':')[0]
+    }
 }

--- a/test/org/pcic/UtilsTest.groovy
+++ b/test/org/pcic/UtilsTest.groovy
@@ -62,4 +62,10 @@ public class UtilsTest {
     public void isPublishable_false() {
         assert utils.isPublishable('badBranch', []) == false
     }
+
+    @Test
+    public void getExceptionType_returnString() {
+        Exception e = new Exception('java.lang.Exception: some test exception')
+        assert utils.getExceptionType(e) == 'java.lang.Exception'
+    }
 }

--- a/vars/reportableStage.groovy
+++ b/vars/reportableStage.groovy
@@ -1,0 +1,27 @@
+import org.pcic.GitHubUtils
+import org.pcic.util.Utils
+
+/**
+ * Run a stage and send a commit status report to github
+ *
+ * @param context the name of the stage to be displayed in the commit status
+ * @param closure the stage steps to perform
+ */
+def call(String context, Closure closure) {
+    GitHubUtils gitHubUtils = new GitHubUtils(this)
+    Utils utils = new Utils(this)
+
+    // Run stage
+    stage(context) {
+        try {
+            gitHubUtils.setBuildStatus(context, 'In progress...', 'PENDING')
+            // Run the steps given to this stage
+            closure()
+            gitHubUtils.setBuildStatus(context, 'Success', 'SUCCESS')
+        } catch (Exception e) {
+            gitHubUtils.setBuildStatus(context, utils.getExceptionType(e),
+                                       'FAILURE')
+            this.error(e.toString())
+        }
+    }
+}


### PR DESCRIPTION
While we can report on the overall status of a build there may be cases where we want to be more specific and report on the stages (long pipelines such as the `pdp`).  This PR adds a feature that behaves like a `stage()` command but will also report that stage to GitHub as a part of the commit status notification widget. 

### Example in Jenkinsfile
Replace the usual `stage()` command
```groovy
stage('Code Collection') {
    // some stage code
}

stage('Run Tests') {
    // some stage code
}
```

With a `reportableStage()` command 
```groovy
reportableStage('Code Collection') {
    // some stage code
}

reportableStage('Run Tests') {
    // some stage code
}
```

And the result on GitHub looks like this:
![image](https://user-images.githubusercontent.com/26128992/72026821-be8e3b00-3231-11ea-9eb2-9afc02129a3d.png)

This PR resolves Issue #4. 