### PR TITLE
Add apt-get installation method

### DIFF
--- a/src/org/pcic/PythonUtils.groovy
+++ b/src/org/pcic/PythonUtils.groovy
@@ -25,11 +25,6 @@ class PythonUtils implements Serializable {
         steps.sh(script: "twine upload --repository-url ${pypiUrl} --skip-existing -u ${username} -p ${password} dist/*")
     }
 
-    void installGitExecutable() {
-        steps.sh(script: 'apt-get update')
-        steps.sh(script: 'apt-get install -y git')
-    }
-
     void installRequirements(String pip, ArrayList requirementsFiles) {
         String required = '-r ' + requirementsFiles.join(' -r ')
         steps.sh(script: "${pip} install ${required}")

--- a/src/org/pcic/util/Global.groovy
+++ b/src/org/pcic/util/Global.groovy
@@ -1,0 +1,8 @@
+package org.pcic.util
+
+
+class Global implements Serializable {
+    static constants = [
+        requireUpdate: ['git']
+    ]
+}

--- a/src/org/pcic/util/Utils.groovy
+++ b/src/org/pcic/util/Utils.groovy
@@ -2,6 +2,7 @@ package org.pcic.util
 
 import org.pcic.GitUtils
 import org.pcic.DockerUtils
+import org.pcic.util.Global
 
 
 class Utils implements Serializable {
@@ -83,7 +84,7 @@ class Utils implements Serializable {
      * @param packages list of packages to install
      */
     void installAptPackages(ArrayList packages) {
-        ArrayList requireUpdate = ['git'].intersect(packages)
+        ArrayList requireUpdate = Global.constants.requireUpdate.intersect(packages)
 
         if (requireUpdate.size() > 0) {
             updatePackageList()

--- a/vars/runPythonTestSuite.groovy
+++ b/vars/runPythonTestSuite.groovy
@@ -12,8 +12,7 @@ import org.pcic.util.Utils
  * @param options map containing any of the optional arguments:
  *                serverUri: URI of the server to publish with
  *                pythonVersion: Version of python being used in the project
- *                gitExecInstall: Set to true if git executable needs to be
- *                                installed
+ *                aptPackages: List of packages to install
  *                buildDocs: Set to true is sphinx docs need to be built
  *                containerData: Generally left as default, `pdp` for pdp data
  *                               from storage
@@ -24,7 +23,7 @@ def call(String imageName, ArrayList requirementsFiles, String pytestArgs, Map o
     PythonUtils pytils = new PythonUtils(this)
     DockerUtils dockerUtils = new DockerUtils(this)
 
-    ArrayList defaults = ['serverUri', 'pythonVersion', 'gitExecInstall',
+    ArrayList defaults = ['serverUri', 'pythonVersion', 'aptPackages',
                           'buildDocs', 'containerData', 'pipIndexUrl']
     Map args = utils.getUpdatedArgs(defaults, options)
 
@@ -36,8 +35,8 @@ def call(String imageName, ArrayList requirementsFiles, String pytestArgs, Map o
         def pytainer = docker.image(imageName)
 
         pytainer.inside(containerDataArgs) {
-            if (args.gitExecInstall) {
-                pytils.installGitExecutable()
+            if (args.aptPackages.size() > 0) {
+                utils.installAptPackages(args.aptPackages)
             }
 
             withEnv(["PIP_INDEX_URL=${args.pipIndexUrl}"]) {


### PR DESCRIPTION
This PR resolves issue #6 by factoring out the `installGitExecutable()` method into the `Utils` class.  The `apt-get` installation process is also generalized such that the method can handle multiple packages.  Furthermore it breaks apart the `update` and `install` functionalities such that they can be used separately if required.