### PR TITLE
Specify type when defining tags

### DIFF
--- a/vars/isPypiPublishable.groovy
+++ b/vars/isPypiPublishable.groovy
@@ -10,6 +10,6 @@ def call() {
     GitUtils gitUtils = new GitUtils(this)
     Utils utils = new Utils(this)
 
-    def tags = gitUtils.isCommitTagged()
+    ArrayList tags = gitUtils.isCommitTagged()
     return utils.isPublishable(BRANCH_NAME, tags)
 }


### PR DESCRIPTION
Very minor change to force stronger typing on the `isPypiPublishable` `step`.  This should resolve #12.