### PR TITLE
Fix general python string usage

### DIFF
--- a/src/org/pcic/PythonUtils.groovy
+++ b/src/org/pcic/PythonUtils.groovy
@@ -8,17 +8,17 @@ class PythonUtils implements Serializable {
         this.steps = steps
     }
 
-    String getPipString(int pythonVersion) {
-        if (pythonVersion == 3) {
-            return 'pip3'
+    String applyPythonVersion(String base, int pythonVersion) {
+        if (pythonVersion != 2) {
+            return base + pythonVersion.toString()
         }
 
-        return 'pip'
+        return base
     }
 
-    void preparePackage(String pip) {
+    void preparePackage(String pip, String python) {
         steps.sh(script: "${pip} install twine wheel")
-        steps.sh(script: 'python setup.py sdist bdist_wheel')
+        steps.sh(script: "${python} setup.py sdist bdist_wheel")
     }
 
     void releasePackage(String pypiUrl, String username, String password) {
@@ -31,10 +31,10 @@ class PythonUtils implements Serializable {
         steps.sh(script: "${pip} install -e .")
     }
 
-    void buildDocs() {
-        steps.sh(script: 'python setup.py install')
-        steps.sh(script: 'python setup.py build_sphinx')
-        steps.sh(script: 'python setup.py install')
+    void buildDocs(String python) {
+        steps.sh(script: "${python} setup.py install")
+        steps.sh(script: "${python} setup.py build_sphinx")
+        steps.sh(script: "${python} setup.py install")
     }
 
     void runPytest(String args) {

--- a/test/org/pcic/PythonUtilsTest.groovy
+++ b/test/org/pcic/PythonUtilsTest.groovy
@@ -16,21 +16,21 @@ public class PythonUtilsTest {
     }
 
     @Test
-    public void getPipString_python2() {
+    public void applyPythonVersion_python2() {
         int version = 2
         String expected = 'pip'
 
-        String result = pythonUtils.getPipString(version)
+        String result = pythonUtils.applyPythonVersion(expected, version)
 
         assert result == expected
     }
 
     @Test
-    public void getPipString_python3() {
+    public void applyPythonVersion_python3() {
         int version = 3
         String expected = 'pip3'
 
-        String result = pythonUtils.getPipString(version)
+        String result = pythonUtils.applyPythonVersion('pip', version)
 
         assert result == expected
     }

--- a/vars/publishPythonPackage.groovy
+++ b/vars/publishPythonPackage.groovy
@@ -20,13 +20,14 @@ def call(String imageName, String credentialsId, Map options = [:]) {
                                     options)
 
     // set up some items used in the commands below
-    String pip = pytils.getPipString(args.pythonVersion)
+    String pip = pytils.applyPythonVersion('pip', args.pythonVersion)
+    String python = pytils.applyPythonVersion('python', args.pythonVersion)
 
     withDockerServer([uri: args.serverUri]) {
         def pytainer = docker.image(imageName)
 
         pytainer.inside {
-            pytils.preparePackage(pip)
+            pytils.preparePackage(pip, python)
 
             withCredentials([usernamePassword(credentialsId: credentialsId,
                                               usernameVariable: 'USERNAME',

--- a/vars/runPythonTestSuite.groovy
+++ b/vars/runPythonTestSuite.groovy
@@ -28,7 +28,8 @@ def call(String imageName, ArrayList requirementsFiles, String pytestArgs, Map o
     Map args = utils.getUpdatedArgs(defaults, options)
 
     // set up some items used in the commands below
-    String pip = pytils.getPipString(args.pythonVersion)
+    String pip = pytils.applyPythonVersion('pip', args.pythonVersion)
+    String python = pytils.applyPythonVersion('python', args.pythonVersion)
     String containerDataArgs = dockerUtils.getContainerArgs(args.containerData)
 
     withDockerServer([uri: args.serverUri]) {
@@ -44,7 +45,7 @@ def call(String imageName, ArrayList requirementsFiles, String pytestArgs, Map o
             }
 
             if (args.buildDocs) {
-                pytils.buildDocs()
+                pytils.buildDocs(python)
             }
 
             pytils.runPytest(pytestArgs)


### PR DESCRIPTION
This PR adds a function to apply the python version to the end of a string.  The reason for this is that when inside the docker images we have to specify which version of python we are using with the `sh` commands.  When in a container based on `python3` using `"python"` in a command will cause a `python: not found` error.

Resolves #14.